### PR TITLE
Minor fixes

### DIFF
--- a/gravy.js
+++ b/gravy.js
@@ -7,9 +7,8 @@
 *   Gravy may be freely distributed under the MIT license.
 *
 */
-Backbone.Gravy = Backbone.View;
 
-_.extend(Backbone.Gravy.prototype, {
+Backbone.Gravy = Backbone.View.extend({
 
     _VERSION : '1.0',
 

--- a/tests/gravy-spec.js
+++ b/tests/gravy-spec.js
@@ -3,6 +3,10 @@ describe("Testing Gravy:", function() {
         this.view = new gravyTestView();
     });
 
+    it("keeps its prototype isolated from Backbone View's",function() {
+         expect(Backbone.Gravy.prototype).toNotBe(Backbone.View.prototype);
+    });
+
     describe("Asserting that default callbacks are invoked..", function() {
         
         beforeEach(function() {


### PR DESCRIPTION
Ensure we're not changing Backbone.View's prototype, and avoid global vars.
